### PR TITLE
callback can be omitted

### DIFF
--- a/lib/lib/slack.seed.js
+++ b/lib/lib/slack.seed.js
@@ -84,7 +84,7 @@ Slack = (function() {
           response: response
         });
       }
-      callback(err, JSON.parse(response));
+      if (callback) callback(err, JSON.parse(response));
     });
     return this;
   };


### PR DESCRIPTION
with a `if` the callback can be omitted, like

```
slack.api('chat.postMessage', {text:'hello from nodejs', channel:'#general'});
```

without the `if` I get this error message

```
 TypeError: undefined is not a function
     at Request._callback (/user/src/slack-node-sdk/lib/lib/slack.seed.js:87:7)
     at Request.self.callback (/user/src/slack-node-sdk/node_modules/request/request.js:121:22)
     at Request.emit (events.js:98:17)
     at Request.<anonymous> (/user/src/slack-node-sdk/node_modules/request/request.js:978:14)
     at Request.emit (events.js:117:20)
     at IncomingMessage.<anonymous> (/user/src/slack-node-sdk/node_modules/request/request.js:929:12)
     at IncomingMessage.emit (events.js:117:20)
     at _stream_readable.js:929:16
     at process._tickCallback (node.js:419:13)
```
