### PR TITLE
wrap json.parse in response with try,catch

### DIFF
--- a/lib/lib/slack.seed.js
+++ b/lib/lib/slack.seed.js
@@ -107,7 +107,13 @@ Slack = (function() {
         });
       }
       if (typeof callback === "function") {
-        callback(err, JSON.parse(response));
+        var res = "";
+        try{
+          res = JSON.parse(response);
+        } catch(e){
+          res = e;
+        }
+        callback(err, res);
       }
     });
     return this;

--- a/lib/lib/slack.seed.js
+++ b/lib/lib/slack.seed.js
@@ -107,13 +107,14 @@ Slack = (function() {
         });
       }
       if (typeof callback === "function") {
-        var res = "";
+        var res = "", error = null;
         try{
           res = JSON.parse(response);
-        } catch(e){
-          res = e;
+        } catch(err){
+          error = new Error( "Couldn't parse Slack API response as JSON:" + err);
         }
-        callback(err, res);
+        
+        callback(error, res);
       }
     });
     return this;


### PR DESCRIPTION
When the response is too large, 
json.parse is throwing error of too long message.