### PR TITLE
Changed form key in POST to force multipart/form-data request

### DIFF
--- a/lib/lib/slack.seed.js
+++ b/lib/lib/slack.seed.js
@@ -94,7 +94,7 @@ Slack = (function() {
     };
     if (this._is_post_api(method)) {
       request_arg.method = "POST";
-      request_arg.form = options;
+      request_arg.formData = options;
     } else {
       request_arg.method = "GET";
       request_arg.qs = options;

--- a/src/lib/slack.seed.coffee
+++ b/src/lib/slack.seed.coffee
@@ -76,7 +76,7 @@ class Slack
 
     if @_is_post_api(method)
       request_arg.method = "POST"
-      request_arg.form = options
+      request_arg.formData = options
     else
       request_arg.method = "GET"
       request_arg.qs = options


### PR DESCRIPTION
The Slack API requires that [files uploaded must use multipart/form-data](https://api.slack.com/methods/files.upload) otherwise you are returned the `invalid_array_arg` error. 

Changing the request form key to formData will make the request library use  multipart/form-data as seen in [the example in the readme](https://github.com/request/request#multipartform-data-multipart-form-uploads)