### PR TITLE
set useQuerystring to true in request_arg

### DIFF
--- a/lib/lib/slack.seed.js
+++ b/lib/lib/slack.seed.js
@@ -100,6 +100,7 @@ Slack = (function() {
     } else {
       request_arg.method = "GET";
       request_arg.qs = options;
+      request_arg.useQuerystring = true;
     }
     request(request_arg, function(err, body, response) {
       var error, parsedResponse;

--- a/src/lib/slack.seed.coffee
+++ b/src/lib/slack.seed.coffee
@@ -82,6 +82,7 @@ class Slack
     else
       request_arg.method = "GET"
       request_arg.qs = options
+      request_arg.useQuerystring = true
 
     request request_arg, (err, body, response) ->
       if err


### PR DESCRIPTION
The slack Web API will give an `invalid_array_arg` error if you pass arrays with the default serialization to the endpoint. This pops up when trying to post, for example, messages with an array of attachements. The `request` library supports an alternate serialization of the form `foo=bar&foo=baz` by setting `useQuerystring=true` in the options.

See https://github.com/request/request#requestoptions-callback and https://api.slack.com/methods/chat.postMessage