### PR TITLE
Improve version of Node.js used for testing travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ sudo: false
 
 node_js:
   - "0.10"
+  - "4"
+  - "6"
+  - "8"
+  - "9"
 
 before_script:
   - make compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - "0.10"
   - "4"
   - "6"
   - "8"


### PR DESCRIPTION
* Add the LTS version and the latest version of Node.js to .travis.yml 
* Remove Node.js 0.10 from .travis.yml
    * The reason is that 0.10 is End-of-Life.

Reference: https://github.com/nodejs/Release